### PR TITLE
Updated SDK ref

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  big_decimal:
+    dependency: transitive
+    description:
+      name: big_decimal
+      sha256: "301158ec5a646d1e1a0ca7a97fbfab7be18a8df700adb7f7cb9c4149e75c8f0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   bip32:
     dependency: transitive
     description:
@@ -381,10 +389,10 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
@@ -597,10 +605,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -741,8 +749,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: HEAD
-      resolved-ref: "7b2d8a33420ba4ed2ef52df8716fce88fbf90773"
+      ref: f3adff23fa6af3882b25bfb8a1d157f04f8a7b5d
+      resolved-ref: f3adff23fa6af3882b25bfb8a1d157f04f8a7b5d
       url: "https://github.com/zenon-network/znn_sdk_dart.git"
     source: git
     version: "0.0.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   znn_sdk_dart:
     git:
       url: https://github.com/zenon-network/znn_sdk_dart.git
+      ref: f3adff23fa6af3882b25bfb8a1d157f04f8a7b5d
 
 dev_dependencies:
   test: ^1.17.9


### PR DESCRIPTION
This commit should resolve the issue causing the message:
```type 'String' is not a subtype of type 'int'```

The previous pubspec.lock did not resolve to an SDK commit that supports BigInt.