### PR TITLE
Fix syntax error caused by missing parentheses

### DIFF
--- a/bin/znn_controller.dart
+++ b/bin/znn_controller.dart
@@ -378,8 +378,8 @@ void _printServiceStatus() {
 bool _verifyProducerConfig(Map<dynamic, dynamic> config) {
   if (!config.containsKey('Producer')) {
     return false;
-  } else if config['Producer'] == null {
-      return false;
+  } else if (config['Producer'] == null) {
+    return false;
   }
   if (!config['Producer'].containsKey('Index') ||
       !config['Producer'].containsKey('KeyFilePath') ||


### PR DESCRIPTION
Fixes the compile error caused by missing parentheses in the `_verifyProducerConfig` function.